### PR TITLE
refactor: Refine cursor behavior on task cards

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -211,11 +211,11 @@ const TodoApp = () => {
           onClick={() => openDetailsModal(task)}
           className={`${getTaskColor(
             task
-          )} p-3 rounded shadow-sm cursor-pointer transition flex items-start space-x-2 relative group`}
+          )} p-3 rounded shadow-sm cursor-move transition flex items-start space-x-2 relative group`}
         >
           <Grip className='w-4 h-4 text-gray-400 mt-1 drag-handle cursor-move' />
           <div className='flex-grow'>
-            <h3 className='font-mono font-semibold text-gray-100'>
+            <h3 className='font-mono font-semibold text-gray-100 cursor-pointer'>
               {task.name}
             </h3>
             {task.description && (


### PR DESCRIPTION
Updated the cursor style on task cards based on your feedback:
- The main task card area now uses `cursor-move` to better indicate draggable functionality.
- The task title specifically now uses `cursor-pointer` to indicate it's clickable to open the details dialog.

This enhances your experience by providing clearer visual cues for interaction.